### PR TITLE
feat: pass colony-scout version from CI

### DIFF
--- a/.github/workflows/publish_gcr.yaml
+++ b/.github/workflows/publish_gcr.yaml
@@ -47,5 +47,5 @@ jobs:
           context: "${{ github.event.inputs.image-folder }}"
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.inputs.image-folder }}:${{ github.event.inputs.image-tag }}
-          build-args:
-            - COLONY_SCOUT_VERSION: ${{ github.event.inputs.colony-scout-version}}
+          build-args: |
+            COLONY_SCOUT_VERSION: ${{ github.event.inputs.colony-scout-version}}

--- a/.github/workflows/publish_gcr.yaml
+++ b/.github/workflows/publish_gcr.yaml
@@ -14,7 +14,7 @@ on:
         required: true
       colony-scout-version:
         description: 'Colony scout machine'
-        default: "v0.2.0-rc1"
+        default: "0.2.0-rc1"
 
 jobs:
   publish_to_public_gcr:

--- a/.github/workflows/publish_gcr.yaml
+++ b/.github/workflows/publish_gcr.yaml
@@ -12,6 +12,9 @@ on:
       image-tag:
         description: 'The image tag to build'
         required: true
+      colony-scout-version:
+        description: 'Colony scout machine'
+        default: "v0.2.0-rc1"
 
 jobs:
   publish_to_public_gcr:
@@ -44,3 +47,5 @@ jobs:
           context: "${{ github.event.inputs.image-folder }}"
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.inputs.image-folder }}:${{ github.event.inputs.image-tag }}
+          build-args:
+            - COLONY_SCOUT_VERSION: ${{ github.event.inputs.colony-scout-version}}

--- a/.github/workflows/publish_gcr.yaml
+++ b/.github/workflows/publish_gcr.yaml
@@ -13,7 +13,7 @@ on:
         description: 'The image tag to build'
         required: true
       colony-scout-version:
-        description: 'Colony scout machine'
+        description: 'Colony scout version'
         default: "0.2.0-rc1"
 
 jobs:
@@ -48,4 +48,4 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.inputs.image-folder }}:${{ github.event.inputs.image-tag }}
           build-args: |
-            COLONY_SCOUT_VERSION: ${{ github.event.inputs.colony-scout-version}}
+            COLONY_SCOUT_VERSION=${{ github.event.inputs.colony-scout-version}}

--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -1,13 +1,18 @@
-FROM alpine:3.13.1
+
+FROM alpine:3.13.1 as downloader
+
+ARG COLONY_SCOUT_VERSION=0.2.0-rc1
 
 RUN apk add --no-cache util-linux wget
 
-ARG COLONY_SCOUT_VERSION=0.0.10-rc11
-RUN wget https://objectstore.nyc1.civo.com/konstruct-assets/colony-scout/v0.0.10-rc11/colony-scout_\ 0.0.10-rc11_Linux_x86_64.tar.gz && \
-    tar -xzvf colony-scout_\ 0.0.10-rc11_Linux_x86_64.tar.gz && \
-    chmod +x colony-scout && \
-    mv colony-scout /usr/local/bin/
+RUN wget https://objectstore.nyc1.civo.com/konstruct-assets/colony-scout/v${COLONY_SCOUT_VERSION}/colony-scout_${COLONY_SCOUT_VERSION}_Linux_x86_64.tar.gz -O ${COLONY_SCOUT_VERSION}.tar.gz && \
+    tar -xzvf "${COLONY_SCOUT_VERSION}.tar.gz" && \
+    chmod +x colony-scout
 
-COPY . .
+FROM alpine:3.13.1
+
+COPY --from=downloader /colony-scout /usr/local/bin
+
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/sh","./entrypoint.sh"]

--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -3,13 +3,15 @@ FROM alpine:3.13.1 as downloader
 
 ARG COLONY_SCOUT_VERSION=0.2.0-rc1
 
-RUN apk add --no-cache util-linux wget
+RUN apk add --no-cache wget
 
 RUN wget https://objectstore.nyc1.civo.com/konstruct-assets/colony-scout/v${COLONY_SCOUT_VERSION}/colony-scout_${COLONY_SCOUT_VERSION}_Linux_x86_64.tar.gz -O ${COLONY_SCOUT_VERSION}.tar.gz && \
     tar -xzvf "${COLONY_SCOUT_VERSION}.tar.gz" && \
     chmod +x colony-scout
 
 FROM alpine:3.13.1
+
+RUN apk add --no-cache util-linux
 
 COPY --from=downloader /colony-scout /usr/local/bin
 

--- a/discovery/entrypoint.sh
+++ b/discovery/entrypoint.sh
@@ -22,7 +22,8 @@ update_hardware() {
   output=$(colony-scout discovery \
     --token="${COLONY_API_KEY}" \
     --colony-api="${COLONY_API_URL}" \
-    --hardware-id="${K1_COLONY_HARDWARE_ID}" 2>&1)
+    --hardware-id="${K1_COLONY_HARDWARE_ID}" \
+    --agent-id="${COLONY_AGENT_ID}" 2>&1)
 
   exit_status=$?
 


### PR DESCRIPTION
## Description
PR adds a CI input for colony-scout version. It uses multistage build to download colony-binary.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
Manually trigger a test action https://github.com/konstructio/colony-scout/actions/runs/14228573161